### PR TITLE
Support Timestamps in where queries

### DIFF
--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -207,7 +207,7 @@ function _recordsGreaterThanValue(records, key, value) {
     if (_shouldCompareNumerically(record[key], value)) {
       return record[key] > value;
     }
-	 if (_shouldCompareTimestamp(record[key], value)) {
+	  if (_shouldCompareTimestamp(record[key], value)) {
       return record[key].toMillis() > value;
     }
     return String(record[key]) > String(value);

--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -1,5 +1,4 @@
 const buildDocFromHash = require('./buildDocFromHash');
-const timestamp = require('../timestamp');
 
 module.exports = function buildQuerySnapShot(requestedRecords, filters) {
   const definiteRecords = requestedRecords.filter(rec => !!rec);

--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -123,7 +123,7 @@ function _recordsLessThanValue(records, key, value) {
     if (_shouldCompareNumerically(record[key], value)) {
       return record[key] < value;
     }
-	if (_shouldCompareTimestamp(record[key], value)) {
+	  if (_shouldCompareTimestamp(record[key], value)) {
       return record[key].toMillis() < value;
     }
     return String(record[key]) < String(value);
@@ -141,7 +141,7 @@ function _recordsLessThanOrEqualToValue(records, key, value) {
     if (_shouldCompareNumerically(record[key], value)) {
       return record[key] <= value;
     }
-	if (_shouldCompareTimestamp(record[key], value)) {
+	  if (_shouldCompareTimestamp(record[key], value)) {
       return record[key].toMillis() <= value;
     }
     return String(record[key]) <= String(value);
@@ -156,10 +156,10 @@ function _recordsLessThanOrEqualToValue(records, key, value) {
  */
 function _recordsEqualToValue(records, key, value) {
   return _recordsWithKey(records, key).filter(record => {
-	if (_shouldCompareTimestamp(record[key], value)) {
+    if (_shouldCompareTimestamp(record[key], value)) {
       return record[key].toMillis() == value;
     }
-	return String(record[key]) === String(value);
+    return String(record[key]) === String(value);
   });
 }
 
@@ -171,10 +171,10 @@ function _recordsEqualToValue(records, key, value) {
  */
 function _recordsNotEqualToValue(records, key, value) {
   return _recordsWithKey(records, key).filter(record => {
-	 if (_shouldCompareTimestamp(record[key], value)) {
+    if (_shouldCompareTimestamp(record[key], value)) {
       return record[key].toMillis() != value;
     }
-	String(record[key]) !== String(value)
+    String(record[key]) !== String(value)
   });
 }
 
@@ -189,7 +189,7 @@ function _recordsGreaterThanOrEqualToValue(records, key, value) {
     if (_shouldCompareNumerically(record[key], value)) {
       return record[key] >= value;
     }
-	if (_shouldCompareTimestamp(record[key], value)) {
+	  if (_shouldCompareTimestamp(record[key], value)) {
       return record[key].toMillis() >= value;
     }
     return String(record[key]) >= String(value);
@@ -207,7 +207,7 @@ function _recordsGreaterThanValue(records, key, value) {
     if (_shouldCompareNumerically(record[key], value)) {
       return record[key] > value;
     }
-	if (_shouldCompareTimestamp(record[key], value)) {
+	 if (_shouldCompareTimestamp(record[key], value)) {
       return record[key].toMillis() > value;
     }
     return String(record[key]) > String(value);


### PR DESCRIPTION
# Description

Currently filtering Timestamps does not work at all because they are compared as strings, this pr adds support for comparing with Date objects.